### PR TITLE
docs: remove RabbitMQ from Opstella stack (replaced by Redis)

### DIFF
--- a/docs/en/intro/cluster.md
+++ b/docs/en/intro/cluster.md
@@ -24,7 +24,6 @@ outline: deep
         <ul style="list-style-type: circle;">
             <li><strong>Minio</strong> = ทำหน้าที่จัดเก็บข้อมูลประเภทไฟล์ เช่น รูปภาพ วิดีโอ เอกสาร และข้อมูลสำรอง</li>
             <li><strong>Postgresql</strong> = เป็นระบบจัดการฐานข้อมูล</li>
-            <li><strong>Rabbitmq</strong> = เครื่องมือทำงานตัวกลางรับส่งข้อความ เพื่อทำการสื่อสารกันในระบบ opstella</li>
             <li><strong>Redis</strong> = เครื่องมือฐานข้อมูลแบบ NoSQL</li>
         </ul>
     </li>

--- a/docs/en/intro/opstella-architecture.md
+++ b/docs/en/intro/opstella-architecture.md
@@ -15,9 +15,8 @@ outline: deep
 5. **PostgreSQL for Opstella:** A relational database management system (RDBMS) for Opstella Core.
 6. **Redis:** An in-memory data store utilized as a cache for the Opstella Core component.
 7. **Dapr:** A distributed application runtime that orchestrates between each Opstella component.
-8. **RabbitMQ:** A message broker system that enables asynchronous communication to each Opstella component.
-9. **Keycloak:** An identity and access management that provides authentication, authorization, and user management for Opstella.
-10. **PostgreSQL for Keycloak:** A relational database management system (RDBMS) for Keycloak.
+8. **Keycloak:** An identity and access management that provides authentication, authorization, and user management for Opstella.
+9. **PostgreSQL for Keycloak:** A relational database management system (RDBMS) for Keycloak.
 
 ### <ins>**Supported Integration Components**</ins>
 

--- a/docs/th/intro/cluster.md
+++ b/docs/th/intro/cluster.md
@@ -24,7 +24,6 @@ outline: deep
         <ul style="list-style-type: circle;">
             <li><strong>Minio</strong> = ทำหน้าที่จัดเก็บข้อมูลประเภทไฟล์ เช่น รูปภาพ วิดีโอ เอกสาร และข้อมูลสำรอง</li>
             <li><strong>Postgresql</strong> = เป็นระบบจัดการฐานข้อมูล</li>
-            <li><strong>Rabbitmq</strong> = เครื่องมือทำงานตัวกลางรับส่งข้อความ เพื่อทำการสื่อสารกันในระบบ opstella</li>
             <li><strong>Redis</strong> = เครื่องมือฐานข้อมูลแบบ NoSQL</li>
         </ul>
     </li>


### PR DESCRIPTION
## Summary

RabbitMQ has been replaced by Redis across the Opstella stack, so this removes RabbitMQ from the documentation.

## Changes

- **`intro/opstella-architecture.md`** — removed RabbitMQ from the *Opstella Components* list and renumbered the remaining items.
- **`intro/cluster.md`** — removed the RabbitMQ entry from the `data-store` namespace list (Devops Cluster).
- Applied to both the English and Thai `cluster.md` (identical content).

> The Thai `opstella-architecture.md` is introduced in #19 and has already been updated there to omit RabbitMQ, so no change is needed here for that file.

## ⚠️ Follow-up needed (diagrams)

Three architecture diagrams still show a **RabbitMQ** node. They are large draw.io-exported SVGs (with embedded raster data), so they cannot be safely hand-edited — they need to be re-exported from the original draw.io source with the RabbitMQ node removed:

- `docs/public/images/intro/what-is-opstella/opstella-architecture.svg`
- `docs/public/images/intro/reference-architecture/standalone-architecture.svg`
- `docs/public/images/intro/reference-architecture/distributed-architecture.svg`

## Verification

- `grep` confirms no remaining `rabbit` references in `.md` / `.ts` / `.js` sources.
- `bun run docs:build` passes with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
