### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 (Node 24 versions)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,23 +26,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
       # - uses: pnpm/action-setup@v3 # Uncomment this if you're using pnpm
-      # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
+      # - uses: oven-sh/setup-bun@v2 # Uncomment this if you're using Bun
       - name: Setup Node
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Install dependencies
         run: bun install # or pnpm install / yarn install / bun install
       - name: Build with VitePress
         run: bun run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

The GitHub Pages deploy workflow was emitting deprecation warnings because several actions still run on the **Node.js 20** runtime, which GitHub forces to Node 24 starting **2026-06-02** and removes on **2026-09-16**.

This bumps each action to its current major version (all run on **Node.js 24**):

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | **v6** |
| `oven-sh/setup-bun` | v1 | **v2** |
| `actions/configure-pages` | v4 | **v6** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

The `upload-artifact@v4` warning came transitively from `upload-pages-artifact@v3`; bumping to v5 resolves it.

## Notes

- Only version pins changed — the inputs/outputs used here (`fetch-depth`, `bun-version`, `path`, `page_url`) are unchanged across these majors, so it's a drop-in update.
- YAML validated; the only file touched is `.github/workflows/deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
